### PR TITLE
Updated gradle dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,11 +49,11 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation "androidx.test:core-ktx:1.4.0"
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation "androidx.test:core-ktx:1.5.0"
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }


### PR DESCRIPTION
To fix #66 the following changes were made:

- Upgrade `androidx.appcompat:appcompat` from version `1.5.1` to `1.6.1`
- Upgrade `com.google.android.material:material` from version `1.7.0` to `1.8.0`
- Upgrade `androidx.test.ext:junit` from version `1.1.3` to `1.1.5`
- Upgrade `androidx.test:core-ktx` from version  `1.4.0` to `1.5.0`
- Upgrade `androidx.test.espresso:espresso-core` from version `3.4.0` to `3.5.1`

**Result**
All tests in LemonadeTests pass
![image](https://user-images.githubusercontent.com/74777051/219792228-f390ec19-7999-4455-90cd-17707a1b9317.png)
